### PR TITLE
Fixed deprecated in system.php line 1081

### DIFF
--- a/system/library/system.php
+++ b/system/library/system.php
@@ -1078,7 +1078,7 @@
 			return false;
 		}
 
-		public static function cpu_idle($pros_stat = array(), $unit, $fcpu = false, $ctrl = false)
+		public static function cpu_idle($pros_stat = array(), $unit = false, $fcpu = false, $ctrl = false)
 		{
 			return sys::cpu_get_idle(sys::parse_cpu($pros_stat[0]), sys::parse_cpu($pros_stat[1]), $unit, $fcpu, $ctrl);
 		}


### PR DESCRIPTION
Deprecated: Required parameter $unit follows optional parameter $pros_stat in C:\OSPanel\domains\localhost\system\library\system.php on line 1081