### PR TITLE
Fixed deprecated in system.php line 273

### DIFF
--- a/system/library/system.php
+++ b/system/library/system.php
@@ -241,6 +241,8 @@
 
 		public static function valid($val, $type, $preg = '')
 		{
+            $val = (isset($val) ? $val : '');
+
 			switch($type)
 			{
 				case 'promo':


### PR DESCRIPTION
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in C:\OSPanel\domains\localhost\system\library\system.php on line 273