### PR TITLE
Fixed deprecated in games.php line124

### DIFF
--- a/system/library/control/control.php
+++ b/system/library/control/control.php
@@ -384,7 +384,7 @@
 			}
 		}
 
-		public static function crontab($data = array(), $id, $cid)
+		public static function crontab($id, $cid, $data = array())
 		{
 			global $cfg;
 

--- a/system/library/games/games.php
+++ b/system/library/games/games.php
@@ -121,7 +121,7 @@
 			return $hour.':'.$minute;
 		}
 
-		public static function crontab($data = array(), $id, $cid)
+		public static function crontab($id, $cid, $data = array())
 		{
 			global $cfg;
 

--- a/system/sections/control/servers/games/settings/crontab.php
+++ b/system/sections/control/servers/games/settings/crontab.php
@@ -68,7 +68,7 @@
 
 		include(LIB.'games/games.php');
 
-		$cron_rule = ctrl::crontab($data, $sid, $cid);
+		$cron_rule = ctrl::crontab($sid, $cid, $data);
 
 		$ssh->set('echo "'.$cron_rule.'" >> /etc/crontab;'
 				."sed -i '/^$/d' /etc/crontab;"

--- a/system/sections/servers/games/settings/crontab.php
+++ b/system/sections/servers/games/settings/crontab.php
@@ -71,7 +71,7 @@
 
 		include(LIB.'games/games.php');
 
-		$cron_rule = games::crontab($data, $id, $cid);
+		$cron_rule = games::crontab($id, $cid, $data);
 
 		$ssh->set('echo "'.$cron_rule.'" >> /etc/crontab;'
 				."sed -i '/^$/d' /etc/crontab;"


### PR DESCRIPTION
Deprecated: Optional parameter $data declared before required parameter $cid is implicitly treated as a required parameter in C:\OSPanel\domains\localhost\system\library\games\games.php on line 124