### PR TITLE
Fixed fatal in games.php line 177

### DIFF
--- a/system/library/games/games.php
+++ b/system/library/games/games.php
@@ -174,7 +174,7 @@
 			else{
 				$weeks = $week[1].','.$week[2].','.$week[3].','.$week[4].','.$week[5].','.$week[6].','.$week[7];
 				$weeks = str_replace(array(',0', '0'), '', $weeks);
-				$week = $weeks{0} == ',' ? substr($weeks, 1) : $weeks;
+				$week = $weeks[0] == ',' ? substr($weeks, 1) : $weeks;
 			}
 
 			$cron_task = $time.$week.' screen -dmS s'.$id.' bash -c \'cd /var/enginegp && php cron.php '.$cfg['cron_key'].' server_cron '.$id.' '.$cid.'\'';


### PR DESCRIPTION
Fatal error: Array and string offset access syntax with curly braces is no longer supported in C:\OSPanel\domains\localhost\system\library\games\games.php on line 177