### PR TITLE
Fixed deprecated in games.php line 262

### DIFF
--- a/system/library/games/games.php
+++ b/system/library/games/games.php
@@ -259,7 +259,7 @@
 			return $data;
 		}
 
-		public static function parse_time($aTime = array(), $discount, $tarif, $type = 'buy')
+		public static function parse_time($aTime, $discount, $tarif, $type = 'buy')
 		{
 			global $cfg;
 


### PR DESCRIPTION
Deprecated: Optional parameter $aTime declared before required parameter $tarif is implicitly treated as a required parameter in C:\OSPanel\domains\localhost\system\library\games\games.php on line 262