### PR TITLE
Fixed deprecated in games.php line 374

### DIFF
--- a/system/library/games/games.php
+++ b/system/library/games/games.php
@@ -371,7 +371,7 @@
 			return $sum;
 		}
 
-		public static function define_promo($cod, $data = array(), $discount, $sum, $type = 'buy')
+		public static function define_promo($cod, $data, $discount, $sum, $type = 'buy')
 		{
 			global $cfg, $sql, $go, $start_point;
 


### PR DESCRIPTION
Deprecated: Optional parameter $data declared before required parameter $sum is implicitly treated as a required parameter in C:\OSPanel\domains\localhost\system\library\games\games.php on line 374