### PR TITLE
Minor fixes

### DIFF
--- a/system/library/html.php
+++ b/system/library/html.php
@@ -8,6 +8,8 @@
         var $template = null;
         var $data = array();
         var $unitblock = array();
+        public $arr;
+        public $select_template;
 
         public function set($name, $var, $unset = false)
         {


### PR DESCRIPTION
PHP message: PHP Deprecated:  Creation of dynamic property html::$select_template is deprecated in /var/enginegp/system/library/html.php on line 78;
PHP message: PHP Deprecated:  Creation of dynamic property html::$arr is deprecated in /var/enginegp/system/library/html.php on line 126" while reading response header from upstream, client: 178.205.103.15, server: enginegp.chmd.online, request: "GET /help/section/notice/go HTTP/1.1", upstream: "fastcgi://unix:/var/run/php/php8.2-fpm.sock:", host: "enginegp.chmd.online", referrer: "http://enginegp.chmd.online/user/section/auth"