### PR TITLE
PHP Deprecated:  Implicit conversion from float 35.6 to int loses precision in /system/library/system.php on line 743

### DIFF
--- a/system/library/system.php
+++ b/system/library/system.php
@@ -740,7 +740,7 @@
             {
                $color = imagecolorallocatealpha($src, $colors[rand(0,sizeof($colors)-1)], $colors[rand(0,sizeof($colors)-1)], $colors[rand(0,sizeof($colors)-1)], rand(20,40)); 
                $char = $chars[rand(0, sizeof($chars)-1)];
-               $size = rand($font_size*2.1-2, $font_size*2.1+2);
+               $size = rand($font_size*((int) 2.1)-2, $font_size*((int) 2.1)+2);
 
                $x = ($i+1)*$font_size + rand(6,8);
                $y = (($height*2)/3) + rand(3,7);


### PR DESCRIPTION
Фикс ошибки, из-за которой не отображалась каптча на php 8.1 и выше
PHP Deprecated:  Implicit conversion from float 35.6 to int loses precision in /system/library/system.php on line 743;
PHP Deprecated:  Implicit conversion from float 31.6 to int loses precision in /system/library/system.php on line 743;