### PR TITLE
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /enginegp/system/library/acpsystem.php on line 105

### DIFF
--- a/system/library/acpsystem.php
+++ b/system/library/acpsystem.php
@@ -75,6 +75,7 @@
 
         public static function valid($val, $type, $preg = '')
         {
+            $val = isset($val) ? $val : '';
             switch($type)
             {
                 case 'promo':


### PR DESCRIPTION
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /enginegp/system/library/acpsystem.php on line 105