### PR TITLE
Update system.php

### DIFF
--- a/system/library/system.php
+++ b/system/library/system.php
@@ -50,7 +50,7 @@
             return NULL;
         }
 
-        public static function users($users = false, $user = false, $authkey = false, $del = false)
+        public static function users($users = [], $user = false, $authkey = false, $del = false)
         {
             global $mcache;
 


### PR DESCRIPTION
Deprecated: Automatic conversion of false to array is deprecated in /var/enginegp/system/library/system.php on line 60