### PR TITLE
PHP Deprecated:  Implicit conversion from float 98.65444444444444 to …

### DIFF
--- a/system/library/acpsystem.php
+++ b/system/library/acpsystem.php
@@ -462,7 +462,7 @@
             if($day)
                 $uptime .= $day.'д. ';
 
-            $hour = $time/60/60%24;
+            $hour = (int)($time/60/60)%24;
             if($hour)
                 $uptime .= $hour.'ч. ';
 


### PR DESCRIPTION
…int loses precision in C:\MyPrograms\OSPanel\domains\enginegp.local\system\library\acpsystem.php on line 465