### PR TITLE
PHP Deprecated:  Implicit conversion from float 5919.266666666666 to …

### DIFF
--- a/system/library/acpsystem.php
+++ b/system/library/acpsystem.php
@@ -466,7 +466,7 @@
             if($hour)
                 $uptime .= $hour.'ч. ';
 
-            $min = $time/60%60;
+            $min = (int)($time/60)%60;
             if($min)
                 $uptime .= $min.'м. ';
             


### PR DESCRIPTION
…int loses precision in C:\MyPrograms\OSPanel\domains\enginegp.local\system\library\acpsystem.php on line 469