### PR TITLE
Deprecated: iconv_strlen(): Passing null to parameter #1 ($string) of…

### DIFF
--- a/system/library/system.php
+++ b/system/library/system.php
@@ -687,6 +687,10 @@
 
         public static function strlen($str)
         {
+            if ($str === null) {
+                return 0;
+            }
+
             return iconv_strlen($str, 'UTF-8');
         }
 


### PR DESCRIPTION
… type string is deprecated in C:\MyPrograms\OSPanel\domains\enginegp.local\system\library\system.php on line 690