### PR TITLE
Fixed: Array and string offset access syntax with curly braces is no …

### DIFF
--- a/system/library/control/control.php
+++ b/system/library/control/control.php
@@ -437,7 +437,7 @@
             else{
                 $weeks = $week[1].','.$week[2].','.$week[3].','.$week[4].','.$week[5].','.$week[6].','.$week[7];
                 $weeks = str_replace(array(',0', '0'), '', $weeks);
-                $week = $weeks{0} == ',' ? substr($weeks, 1) : $weeks;
+                $week = $weeks[0] == ',' ? substr($weeks, 1) : $weeks;
             }
 
             $cron_task = $time.$week.' screen -dmS s'.$id.' bash -c \'cd /var/enginegp && php cron.php '.$cfg['cron_key'].' control_server_cron '.$id.' '.$cid.'\'';


### PR DESCRIPTION
…longer supported

Array and string offset access syntax with curly braces is no longer supported in file /var/enginegp/system/library/control/control.php on line 440