### PR TITLE
foreach() argument must be of type array|object, null given in file /…

### DIFF
--- a/system/acp/sections/tarifs/tarif.php
+++ b/system/acp/sections/tarifs/tarif.php
@@ -474,10 +474,14 @@
 
         $aPlugins = sys::b64djs($tarif['plugins_install']);
 
-        foreach($aPlugins as $pack => $list)
-            $plugins .= '"'.$pack.'":"'.$list.'",';
+        if(is_array($aPlugins) || is_object($aPlugins)) {
+            foreach($aPlugins as $pack => $list) {
+                $plugins .= '"'.$pack.'":"'.$list.'",';
+            }
+        }
 
-        $plugins = isset($plugins{0}) ? substr($plugins, 0, -1) : '';
+
+$plugins = isset($plugins{0}) ? substr($plugins, 0, -1) : '';
 
         $html->set('plugins_install', $plugins);
 


### PR DESCRIPTION
…var/enginegp/system/acp/sections/tarifs/tarif.php on line 477

[2023-04-29 15:54:14] EngineGP.ERROR: Whoops\Exception\ErrorException: foreach() argument must be of type array|object, null given in file /var/enginegp/system/acp/sections/tarifs/tarif.php on line 477 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/enginegp/system/acp/sections/tarifs/tarif.php:477
  2. Whoops\Run->handleError() /var/enginegp/system/acp/sections/tarifs/tarif.php:477
  3. include() /var/enginegp/system/acp/sections/tarifs/index.php:9
  4. include() /var/enginegp/system/acp/engine/tarifs.php:32
  5. include() /var/enginegp/system/acp/distributor.php:66
  6. include() /var/enginegp/acp/index.php:50 [] []