### PR TITLE
(Fixed) Array and string offset access syntax with curly braces is no…

### DIFF
--- a/system/library/ftp.php
+++ b/system/library/ftp.php
@@ -114,10 +114,10 @@ class ftp
             }
 
         foreach ($rawlist as $name => $data) {
-            if ($data['chmod']{0} == 'd')
+            if ($data['chmod'][0] == 'd')
                 $aDir[$name] = $data;
 
-            elseif ($data['chmod']{0} == '-')
+            elseif ($data['chmod'][0] == '-')
                 $aFile[$name] = $data;
         }
 
@@ -154,7 +154,7 @@ class ftp
 
                 $path = $view['path'];
 
-                if ($path{0} != '/') $path = '/' . $path;
+                if ($path[0] != '/') $path = '/' . $path;
 
                 if ($path != '/') $path = $path . '/';
 
@@ -379,7 +379,7 @@ class ftp
 
             $path = $data['dir'];
 
-            if ($path{0} != '/') $path = '/' . $path;
+            if ($path[0] != '/') $path = '/' . $path;
 
             if ($path != '/') $path = $path . '/';
 
@@ -388,7 +388,7 @@ class ftp
             $html->set('owner', $info[2]);
             $html->set('group', $info[3]);
 
-            if ($info[0]{0} == 'd') {
+            if ($info[0][0] == 'd') {
                 $html->unit('folder', 1);
                 $html->unit('file');
                 $html->set('size', '');


### PR DESCRIPTION
… longer supported

[2023-05-09 17:44:20] EngineGP.ERROR: Whoops\Exception\ErrorException: Array and string offset access syntax with curly braces is no longer supported in file /var/enginegp/system/library/ftp.php on line 117
Stack trace:
  1. Whoops\Exception\ErrorException->() /var/enginegp/system/library/ftp.php:117
  2. Whoops\Run->handleError() /var/enginegp/vendor/filp/whoops/src/Whoops/Run.php:514
  3. Whoops\Run->handleShutdown() [internal]:0
 [] []
[2023-05-09 17:47:38] EngineGP.ERROR: Whoops\Exception\ErrorException: Array and string offset access syntax with curly braces is no longer supported in file /var/enginegp/system/library/ftp.php on line 157
Stack trace:
  1. Whoops\Exception\ErrorException->() /var/enginegp/system/library/ftp.php:157
  2. Whoops\Run->handleError() /var/enginegp/vendor/filp/whoops/src/Whoops/Run.php:514
  3. Whoops\Run->handleShutdown() [internal]:0
 [] []
[2023-05-09 17:48:26] EngineGP.ERROR: Whoops\Exception\ErrorException: Array and string offset access syntax with curly braces is no longer supported in file /var/enginegp/system/library/ftp.php on line 382
Stack trace:
  1. Whoops\Exception\ErrorException->() /var/enginegp/system/library/ftp.php:382
  2. Whoops\Run->handleError() /var/enginegp/vendor/filp/whoops/src/Whoops/Run.php:514
  3. Whoops\Run->handleShutdown() [internal]:0
 [] []
[2023-05-09 17:49:20] EngineGP.ERROR: Whoops\Exception\ErrorException: Array and string offset access syntax with curly braces is no longer supported in file /var/enginegp/system/library/ftp.php on line 391
Stack trace:
  1. Whoops\Exception\ErrorException->() /var/enginegp/system/library/ftp.php:391
  2. Whoops\Run->handleError() /var/enginegp/vendor/filp/whoops/src/Whoops/Run.php:514
  3. Whoops\Run->handleShutdown() [internal]:0
 [] []