### PR TITLE
Added checking memcache extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "require": {
+    "ext-memcache": "*",
     "symfony/polyfill": "1.28.0",
     "symfony/dotenv": "5.4.35",
     "filp/whoops": "2.15.4",


### PR DESCRIPTION
Теперь если у пользователя нету memcache расширения на сервере, то при установке пакетов - ему будет выдана ошибка.