### PR TITLE
Undefined variable: url_search when switching to the control service

### DIFF
--- a/system/acp/sections/control/index.php
+++ b/system/acp/sections/control/index.php
@@ -20,7 +20,8 @@ if (isset($url['subsection']) and $url['subsection'] == 'search')
 if ($id)
     include(SEC . 'control/server.php');
 else {
-    $list = '';
+    $list = null;
+    $url_search = null;
 
     $status = array(
         'working' => '<span class="text-green">Работает</span>',


### PR DESCRIPTION
Whoops\Exception\ErrorException thrown with message "Undefined variable: url_search"

Stacktrace:
# 4 Whoops\Exception\ErrorException in /var/www/enginegp/system/acp/sections/control/index.php:49 # 3 Whoops\Run:handleError in /var/www/enginegp/system/acp/sections/control/index.php:49 # 2 include in /var/www/enginegp/system/acp/engine/control.php:36 # 1 include in /var/www/enginegp/system/acp/distributor.php:86 # 0 include in /var/www/enginegp/acp/index.php:47

Task:
https://bugs.enginegp.com/view.php?id=34