### PR TITLE
Undefined variable: url_search when navigating to the list of wiki ca…

### DIFF
--- a/system/acp/sections/wiki/cats.php
+++ b/system/acp/sections/wiki/cats.php
@@ -15,6 +15,9 @@ if (!DEFINED('EGP'))
     exit(header('Refresh: 0; URL=http://' . $_SERVER['HTTP_HOST'] . '/404'));
 
 $cats = $sql->query('SELECT `id`, `name`, `sort` FROM `wiki_category` ORDER BY `id` ASC');
+
+$list = null;
+
 while ($cat = $sql->get($cats)) {
     $sql->query('SELECT `name` FROM `wiki` WHERE `cat`="' . $cat['id'] . '"');
     $wiki = $sql->num();


### PR DESCRIPTION
…tegories

Whoops\Exception\ErrorException thrown with message "Undefined variable: list"

Stacktrace:
Whoops\Exception\ErrorException in /var/www/enginegp/system/acp/sections/wiki/cats.php:10
Whoops\Run:handleError in /var/www/enginegp/system/acp/sections/wiki/cats.php:10
include in /var/www/enginegp/system/acp/engine/wiki.php:30
include in /var/www/enginegp/system/acp/distributor.php:86
include in /var/www/enginegp/acp/index.php:47

Task:
https://bugs.enginegp.com/view.php?id=35