### PR TITLE
Error with building cron directories in php 8.0

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -36,7 +36,7 @@ if ($_ENV['RUN_MODE'] === 'dev') {
 }
 
 DEFINE('EGP', TRUE);
-DEFINE('DIR', dirname('index.php'));
+DEFINE('DIR', __DIR__);
 DEFINE('ROOT', DIR . '/');
 DEFINE('SYS', ROOT . 'system/');
 DEFINE('TPL', ROOT . 'template/');


### PR DESCRIPTION
PHP Warning: include(): Failed opening './system/data/config.php' for inclusion (include_path='.:/usr/share/php') in /var/www/enginegp/cron.php on line 57
PHP Warning: Undefined variable $cfg in /var/www/enginegp/cron.php on line 60
PHP Warning: Trying to access array offset on value of type null in /var/www/enginegp/cron.php on line 60

Task:
https://bugs.enginegp.com/view.php?id=52
https://bugs.enginegp.com/view.php?id=53
https://bugs.enginegp.com/view.php?id=54