### PR TITLE
Required parameter $id follows optional parameter $data in file /var/…

### DIFF
--- a/system/library/control/control.php
+++ b/system/library/control/control.php
@@ -380,7 +380,7 @@ class ctrl
         }
     }
 
-    public static function crontab($data = array(), $id, $cid)
+    public static function crontab($id, $cid, $data = array())
     {
         global $cfg;
 

--- a/system/sections/control/servers/games/settings/crontab.php
+++ b/system/sections/control/servers/games/settings/crontab.php
@@ -78,7 +78,7 @@ if ($go) {
 
     include(LIB . 'games/games.php');
 
-    $cron_rule = ctrl::crontab($data, $sid, $cid);
+    $cron_rule = ctrl::crontab($sid, $cid, $data);
 
     $ssh->set('echo "' . $cron_rule . '" >> /etc/crontab;'
         . "sed -i '/^$/d' /etc/crontab;"


### PR DESCRIPTION
…www/enginegp/system/library/control/control.php on line 383

[2024-06-06T22:26:02.219342+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Required parameter $id follows optional parameter $data in file /var/www/enginegp/system/library/control/control.php on line 383 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/control/control.php:383
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/cron/scan_control.php:24
  3. include() /var/www/enginegp/system/library/cron/scan_control.php:24
  4. scan_control->__construct() /var/www/enginegp/system/library/cron.php:98
  5. include() /var/www/enginegp/cron.php:72 [] []

Task:
https://bugs.enginegp.com/view.php?id=58