### PR TITLE
Error: Access to undeclared static property action::$argv in file /va…

### DIFF
--- a/system/library/cron/server_action.php
+++ b/system/library/cron/server_action.php
@@ -58,7 +58,7 @@ class server_action extends cron
         if ($argv[3] == 'restart')
             action::start($argv[5], 'restart');
         else
-            action::$argv[3]($argv[5]);
+            action::start($argv[5]);
 
         return NULL;
     }


### PR DESCRIPTION
…r/www/enginegp/system/library/cron/server_action.php on line 61

[2024-06-06T22:30:04.071712+03:00] EngineGP.ERROR: Error: Access to undeclared static property action::$argv in file /var/www/enginegp/system/library/cron/server_action.php on line 61 Stack trace:
  1. Error->() /var/www/enginegp/system/library/cron/server_action.php:61
  2. server_action->__construct() /var/www/enginegp/system/library/cron.php:98
  3. include() /var/www/enginegp/cron.php:72 [] []

Task:
https://bugs.enginegp.com/view.php?id=59