### PR TITLE
TypeError: count(): Argument #1 ($value) must be of type Countable|ar…

### DIFF
--- a/system/sections/servers/games/copy/recfull.php
+++ b/system/sections/servers/games/copy/recfull.php
@@ -64,7 +64,7 @@ $aPlugins = explode(',', $copy['plugins']);
 foreach ($aPlugins as $plugin) {
     $aPlugin = explode('.', $plugin);
 
-    if (!count($aPlugin != 2))
+    if (count($aPlugin) != 2)
         continue;
 
     if (!$aPlugin[0])


### PR DESCRIPTION
…ray, bool given in file /var/www/enginegp/system/sections/servers/games/copy/recfull.php on line 67

[2024-06-07T00:19:51.342463+03:00] EngineGP.ERROR: TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in file /var/www/enginegp/system/sections/servers/games/copy/recfull.php on line 67 Stack trace:
  1. TypeError->() /var/www/enginegp/system/sections/servers/games/copy/recfull.php:67
  2. include() /var/www/enginegp/system/sections/servers/cs/copy.php:42
  3. include() /var/www/enginegp/system/sections/servers/copy.php:22
  4. include() /var/www/enginegp/system/engine/servers.php:94
  5. include() /var/www/enginegp/system/distributor.php:79
  6. include() /var/www/enginegp/index.php:71 [] []

Task:
https://bugs.enginegp.com/view.php?id=60