### PR TITLE
Required parameter $id follows optional parameter $data in file /var/…

### DIFF
--- a/system/library/games/games.php
+++ b/system/library/games/games.php
@@ -132,7 +132,7 @@ class games
         return $hour . ':' . $minute;
     }
 
-    public static function crontab($data = array(), $id, $cid)
+    public static function crontab($id, $cid, $data = array())
     {
         global $cfg;
 

--- a/system/sections/servers/games/settings/crontab.php
+++ b/system/sections/servers/games/settings/crontab.php
@@ -81,7 +81,7 @@ if ($go) {
 
     include(LIB . 'games/games.php');
 
-    $cron_rule = games::crontab($data, $id, $cid);
+    $cron_rule = games::crontab($id, $cid, $data);
 
     $ssh->set('echo "' . $cron_rule . '" >> /etc/crontab;'
         . "sed -i '/^$/d' /etc/crontab;"


### PR DESCRIPTION
…www/enginegp/system/library/games/games.php on line 135

[2024-06-08T18:22:09.485156+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Required parameter $id follows optional parameter $data in file /var/www/enginegp/system/library/games/games.php on line 135 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/games/games.php:135
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/cron/server_delete.php:74
  3. include() /var/www/enginegp/system/library/cron/server_delete.php:74
  4. server_delete->__construct() /var/www/enginegp/system/library/cron.php:98
  5. include() /var/www/enginegp/cron.php:72 [] []

Task:
https://bugs.enginegp.com/view.php?id=66