### PR TITLE
Required parameter $discount follows optional parameter $aTime in fil…

### DIFF
--- a/system/library/games/games.php
+++ b/system/library/games/games.php
@@ -250,7 +250,7 @@ class games
 
         $aTime = explode(':', $aTarif['time']);
 
-        $time = games::parse_time($aTime, $aTarif['discount'], $aTarif['id']);
+        $time = games::parse_time($aTarif['discount'], $aTarif['id'], $aTime);
 
         if ($aTarif['test'] and $aUnit['test'])
             $time .= '<option value="test">Тестовый период ' . games::parse_day($aTarif['test']) . '</option>';
@@ -269,7 +269,7 @@ class games
         return $data;
     }
 
-    public static function parse_time($aTime = array(), $discount, $tarif, $type = 'buy')
+    public static function parse_time($discount, $tarif, $aTime = array(), $type = 'buy')
     {
         global $cfg;
 

--- a/system/sections/servers/games/tarif.php
+++ b/system/sections/servers/games/tarif.php
@@ -42,7 +42,7 @@ $html->pack('main');
 if ($cfg['settlement_period'])
     tarif::extend_sp($server, $tarif, $id);
 else {
-    $options = games::parse_time(explode(':', $tarif['timext']), $tarif['discount'], $server['tarif'], 'extend');
+    $options = games::parse_time($tarif['discount'], $server['tarif'], explode(':', $tarif['timext']), 'extend');
 
     tarif::extend($options, $server, $tarif['name'], $id);
 }


### PR DESCRIPTION
…e /var/www/enginegp/system/library/games/games.php on line 272

Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/games/games.php:272
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/cron/server_delete.php:74
  3. include() /var/www/enginegp/system/library/cron/server_delete.php:74
  4. server_delete->__construct() /var/www/enginegp/system/library/cron.php:98
  5. include() /var/www/enginegp/cron.php:72 [] []

Task:
https://bugs.enginegp.com/view.php?id=67