### PR TITLE
Undefined variable $start_point in file /var/www/enginegp/system/libr…

### DIFF
--- a/system/library/cron/server_delete.php
+++ b/system/library/cron/server_delete.php
@@ -20,6 +20,8 @@ class server_delete extends cron
     {
         global $cfg, $sql, $argv;
 
+        $start_point = $_SERVER['REQUEST_TIME'];
+
         $sql->query('SELECT `id`, `uid`, `user`, `unit`, `tarif`, `game`, `slots`, `address`, `ddos` FROM `servers` WHERE `id`="' . $argv[3] . '" AND `user`="-1" LIMIT 1');
 
         if (!$sql->num())


### PR DESCRIPTION
…ary/cron/server_delete.php on line 149

[2024-06-09T02:46:05.772642+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Undefined variable $start_point in file /var/www/enginegp/system/library/cron/server_delete.php on line 149 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/cron/server_delete.php:149
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/cron/server_delete.php:149
  3. server_delete->__construct() /var/www/enginegp/system/library/cron.php:98
  4. include() /var/www/enginegp/cron.php:72 [] []

Task:
https://bugs.enginegp.com/view.php?id=69