### PR TITLE
Undefined array key "core_fix" in file /var/www/enginegp/system/libra…

### DIFF
--- a/system/library/games/actions.php
+++ b/system/library/games/actions.php
@@ -255,7 +255,7 @@ class actions
         $taskset = '';
 
         // Если включена система автораспределения и не установлен фиксированный поток
-        if ($cfg['cpu_route'] && !$server['core_fix']) {
+        if (isset($cfg['cpu_route']) && $cfg['cpu_route'] && !isset($server['core_fix']) || !$server['core_fix']) {
             $proc_stat = array();
 
             $proc_stat[0] = $ssh->get('cat /proc/stat');
@@ -280,7 +280,7 @@ class actions
             $taskset = 'taskset -c ' . $core;
         }
 
-        if ($server['core_fix']) {
+        if (isset($server['core_fix']) && $server['core_fix']) {
             $core = $server['core_fix'] - 1;
             $taskset = 'taskset -c ' . $core;
         }


### PR DESCRIPTION
…ry/games/actions.php on line 258

[2024-06-07T01:39:32.037684+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Undefined array key "core_fix" in file /var/www/enginegp/system/library/games/actions.php on line 258 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/games/actions.php:258
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/games/actions.php:258
  3. actions->update() /var/www/enginegp/system/sections/servers/action.php:74
  4. include() /var/www/enginegp/system/engine/servers.php:94
  5. include() /var/www/enginegp/system/distributor.php:79
  6. include() /var/www/enginegp/index.php:71 [] []

Task:
https://bugs.enginegp.com/view.php?id=63