### PR TITLE
Implicit conversion from float 31.6 to int loses precision in file /v…

### DIFF
--- a/system/library/system.php
+++ b/system/library/system.php
@@ -687,11 +687,11 @@ class sys
     {
         global $mcache;
 
-        $cod = '';
+        $cod = null;
         $width = 100;
         $height = 45;
         $font_size = 16;
-        $symbols = 3;
+        $symbols = 4;
         $symbols_fon = 20;
         $font = LIB . 'captcha/text.ttf';
 
@@ -709,17 +709,17 @@ class sys
             $char = $chars[rand(0, sizeof($chars) - 1)];
             $size = rand($font_size - 2, $font_size + 2);
 
-            imagettftext($src, $size, rand(0, 45), rand($width * 0.1, $width - $width * 0.1), rand($height * 0.2, $height), $color, $font, $char);
+            imagettftext($src, $size, rand(0, 45), rand((int)($width * 0.1), $width - (int)($width * 0.1)), rand((int)($height * 0.2), $height), $color, $font, $char);
         }
 
         $i = 0;
         for ($i; $i < $symbols; $i += 1) {
             $color = imagecolorallocatealpha($src, $colors[rand(0, sizeof($colors) - 1)], $colors[rand(0, sizeof($colors) - 1)], $colors[rand(0, sizeof($colors) - 1)], rand(20, 40));
             $char = $chars[rand(0, sizeof($chars) - 1)];
-            $size = rand($font_size * 2.1 - 2, $font_size * 2.1 + 2);
+            $size = rand((int)($font_size * 2.1 - 2), (int)($font_size * 2.1 + 2));
 
             $x = ($i + 1) * $font_size + rand(6, 8);
-            $y = (($height * 2) / 3) + rand(3, 7);
+            $y = ((int)(($height * 2) / 3)) + rand(3, 7);
 
             $cod .= $char;
 


### PR DESCRIPTION
…ar/www/enginegp/system/library/system.php on line 719

[2024-06-12T14:34:49.676968+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Implicit conversion from float 31.6 to int loses precision in file /var/www/enginegp/system/library/system.php on line 719 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/system.php:719
  2. rand() /var/www/enginegp/system/library/system.php:719
  3. sys->captcha() /var/www/enginegp/system/sections/user/auth.php:20
  4. include() /var/www/enginegp/system/engine/user.php:35
  5. include() /var/www/enginegp/system/distributor.php:77
  6. include() /var/www/enginegp/index.php:69 [] []