### PR TITLE
Passing null to parameter #2 ($flags) of type int is deprecated in fi…

### DIFF
--- a/system/sections/servers/crmp/console.php
+++ b/system/sections/servers/crmp/console.php
@@ -38,7 +38,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/cs/console.php
+++ b/system/sections/servers/cs/console.php
@@ -56,7 +56,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/cs2/console.php
+++ b/system/sections/servers/cs2/console.php
@@ -56,7 +56,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/csgo/console.php
+++ b/system/sections/servers/csgo/console.php
@@ -56,7 +56,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/css/console.php
+++ b/system/sections/servers/css/console.php
@@ -56,7 +56,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/cssold/console.php
+++ b/system/sections/servers/cssold/console.php
@@ -56,7 +56,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/mc/console.php
+++ b/system/sections/servers/mc/console.php
@@ -56,7 +56,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/mta/console.php
+++ b/system/sections/servers/mta/console.php
@@ -56,7 +56,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/rust/console.php
+++ b/system/sections/servers/rust/console.php
@@ -56,7 +56,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);

--- a/system/sections/servers/samp/console.php
+++ b/system/sections/servers/samp/console.php
@@ -38,7 +38,7 @@ if ($go) {
 
     $output = $ssh->get($command);
 
-    sys::out(htmlspecialchars($output, NULL, ''));
+    sys::out(htmlspecialchars($output, ENT_QUOTES, ''));
 }
 
 $html->nav($server['address'], $cfg['http'] . 'servers/id/' . $id);


### PR DESCRIPTION
…le /var/www/enginegp/system/sections/servers/cs/console.php on line 61

[2024-06-10T02:19:37.099200+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: htmlspecialchars(): Passing null to parameter #2 ($flags) of type int is deprecated in file /var/www/enginegp/system/sections/servers/cs/console.php on line 61 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/sections/servers/cs/console.php:61
  2. htmlspecialchars() /var/www/enginegp/system/sections/servers/cs/console.php:61
  3. include() /var/www/enginegp/system/sections/servers/console.php:22
  4. include() /var/www/enginegp/system/engine/servers.php:94
  5. include() /var/www/enginegp/system/distributor.php:79
  6. include() /var/www/enginegp/index.php:71 [] []

Task:
https://bugs.enginegp.com/view.php?id=71