### PR TITLE
Implicit conversion from float 87.17305555555555 to int loses precisi…

### DIFF
--- a/system/library/acpsystem.php
+++ b/system/library/acpsystem.php
@@ -453,21 +453,25 @@ class sys
 
     public static function uptime_load($time)
     {
-        $uptime = '';
+        $uptime = null;
 
-        $day = floor($time / 60 / 60 / 24);
+        $day = floor($time / 86400);
         if ($day)
             $uptime .= $day . 'д. ';
 
-        $hour = $time / 60 / 60 % 24;
+        $hour = floor(($time % 86400) / 3600);
         if ($hour)
             $uptime .= $hour . 'ч. ';
 
-        $min = $time / 60 % 60;
+        $min = floor(($time % 3600) / 60);
         if ($min)
             $uptime .= $min . 'м. ';
 
-        return $uptime . ($time % 60) . 'с.';
+        $sec = $time % 60;
+        if ($sec)
+            $uptime .= $sec . 'с. ';
+
+        return $uptime;
     }
 
     public static function ram_load($data)


### PR DESCRIPTION
…on in file /var/www/enginegp/system/library/acpsystem.php on line 464

[2024-06-10T02:28:16.425769+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Implicit conversion from float 87.17305555555555 to int loses precision in file /var/www/enginegp/system/library/acpsystem.php on line 464 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/acpsystem.php:464
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/acpsystem.php:464
  3. sys->uptime_load() /var/www/enginegp/system/acp/sections/units/loading.php:77
  4. include() /var/www/enginegp/system/acp/engine/units.php:44
  5. include() /var/www/enginegp/system/acp/distributor.php:69
  6. include() /var/www/enginegp/acp/index.php:71 [] []
  
  Task:
  https://bugs.enginegp.com/view.php?id=73