### PR TITLE
Undefined variable $cur in file /var/www/enginegp/system/acp/sections…

### DIFF
--- a/system/acp/sections/logs/search.php
+++ b/system/acp/sections/logs/search.php
@@ -75,7 +75,7 @@ while ($log = $sql->get()) {
     $list .= '<td>' . $log['id'] . '</td>';
     $list .= '<td>' . $log['text'] . '</td>';
     $list .= '<td class="text-center"><a href="' . $cfg['http'] . 'acp/users/id/' . $log['user'] . '">USER_' . $log['user'] . '</a></td>';
-    $list .= '<td class="text-center">' . $log['money'] . ' ' . $cur['currency'] . '</td>';
+    $list .= '<td class="text-center">' . $log['money'] . ' ' . $cfg['currency'] . '</td>';
     $list .= '<td class="text-center">' . date('d.m.Y - H:i:s', $log['date']) . '</td>';
     $list .= '</tr>';
 }


### PR DESCRIPTION
…/logs/search.php on line 80

[2024-06-10T02:34:16.512498+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Undefined variable $cur in file /var/www/enginegp/system/acp/sections/logs/search.php on line 80 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/acp/sections/logs/search.php:80
  2. Whoops\Run->handleError() /var/www/enginegp/system/acp/sections/logs/search.php:80
  3. include() /var/www/enginegp/system/acp/engine/logs.php:44
  4. include() /var/www/enginegp/system/acp/distributor.php:69
  5. include() /var/www/enginegp/acp/index.php:71 [] []

Task:
https://bugs.enginegp.com/view.php?id=74