### PR TITLE
Automatic conversion of false to array is deprecated in file /var/www…

### DIFF
--- a/system/acp/sections/boost/index.php
+++ b/system/acp/sections/boost/index.php
@@ -42,6 +42,8 @@ if (!$month)
 $aData = $mcache->get('data_boost_all');
 
 if (!is_array($aData)) {
+    $aData = array();
+
     $sql->query('SELECT SUM(`circles`), SUM(`money`) FROM `boost`');
     $data = $sql->get();
 


### PR DESCRIPTION
…/enginegp/system/acp/sections/boost/index.php on line 50

[2024-06-10T02:34:44.430172+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Automatic conversion of false to array is deprecated in file /var/www/enginegp/system/acp/sections/boost/index.php on line 50 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/acp/sections/boost/index.php:50
  2. Whoops\Run->handleError() /var/www/enginegp/system/acp/sections/boost/index.php:50
  3. include() /var/www/enginegp/system/acp/engine/boost.php:51
  4. include() /var/www/enginegp/system/acp/distributor.php:69
  5. include() /var/www/enginegp/acp/index.php:71 [] []

Task:
https://bugs.enginegp.com/view.php?id=75