### PR TITLE
base64_decode(): Passing null to parameter #1 ($string) of type strin…

### DIFF
--- a/system/library/games/crmp/scan.php
+++ b/system/library/games/crmp/scan.php
@@ -54,7 +54,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status'], $server['game']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/cs/scan.php
+++ b/system/library/games/cs/scan.php
@@ -54,7 +54,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/cs2/scan.php
+++ b/system/library/games/cs2/scan.php
@@ -54,7 +54,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/csgo/scan.php
+++ b/system/library/games/csgo/scan.php
@@ -54,7 +54,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/css/scan.php
+++ b/system/library/games/css/scan.php
@@ -54,7 +54,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/cssold/scan.php
+++ b/system/library/games/cssold/scan.php
@@ -54,7 +54,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/mc/scan.php
+++ b/system/library/games/mc/scan.php
@@ -56,7 +56,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status'], $server['game']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/mta/scan.php
+++ b/system/library/games/mta/scan.php
@@ -56,7 +56,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status'], $server['game']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/rust/scan.php
+++ b/system/library/games/rust/scan.php
@@ -54,7 +54,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 

--- a/system/library/games/samp/scan.php
+++ b/system/library/games/samp/scan.php
@@ -54,7 +54,7 @@ class scan extends scans
             $out['buttons'] = sys::buttons($id, $server['status'], $server['game']);
 
             if ($players_get)
-                $out['players'] = base64_decode($server['players']);
+                $out['players'] = base64_decode($server['players'] ?? '');
 
             $mcache->set($nmch, $out, false, $cfg['mcache_server_mon']);
 


### PR DESCRIPTION
…g is deprecated in file /var/www/enginegp/system/library/games/cs/scan.php on line 57

[2024-06-12T23:26:39.671457+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: base64_decode(): Passing null to parameter # 1 ($string) of type string is deprecated in file /var/www/enginegp/system/library/games/cs/scan.php on line 57 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/games/cs/scan.php:57
  2. base64_decode() /var/www/enginegp/system/library/games/cs/scan.php:57
  3. scan->mon() /var/www/enginegp/system/sections/servers/scan.php:26
  4. include() /var/www/enginegp/system/engine/servers.php:92
  5. include() /var/www/enginegp/system/distributor.php:77
  6. include() /var/www/enginegp/index.php:69 [] []

Task:
https://bugs.enginegp.com/view.php?id=78