### PR TITLE
Error: Non-static method api::console() cannot be called statically i…

### DIFF
--- a/system/engine/api.php
+++ b/system/engine/api.php
@@ -46,7 +46,6 @@ switch ($action) {
 
     case 'console':
         $cmd = isset($url['command']) ? $url['command'] : false;
-
         sys::outjs(api::console($id, $cmd));
 }
 

--- a/system/library/api.php
+++ b/system/library/api.php
@@ -14,7 +14,7 @@ if (!defined('EGP'))
 
 class api
 {
-    public function data($id)
+    public static function data($id)
     {
         global $sql, $cfg;
 
@@ -58,7 +58,7 @@ class api
         );
     }
 
-    public function load($id)
+    public static function load($id)
     {
         global $sql, $cfg;
 
@@ -80,7 +80,7 @@ class api
         );
     }
 
-    public function console($id, $cmd)
+    public static function console($id, $cmd)
     {
         global $sql, $cfg;
 


### PR DESCRIPTION
…n file /var/www/enginegp/system/engine/api.php

	[2024-06-16T01:51:28.434276+03:00] EngineGP.ERROR: Error: Non-static method api::console() cannot be called statically in file /var/www/enginegp/system/engine/api.php on line 50
Stack trace:
  1. Error->() /var/www/enginegp/system/engine/api.php:50
  2. include() /var/www/enginegp/system/distributor.php:77
  3. include() /var/www/enginegp/index.php:69 [] []

[2024-06-16T01:54:12.095670+03:00] EngineGP.ERROR: Error: Non-static method api::load() cannot be called statically in file /var/www/enginegp/system/engine/api.php on line 45 Stack trace:
  1. Error->() /var/www/enginegp/system/engine/api.php:45
  2. include() /var/www/enginegp/system/distributor.php:77
  3. include() /var/www/enginegp/index.php:69 [] []

	[2024-06-16T01:55:20.650480+03:00] EngineGP.ERROR: Error: Non-static method api::data() cannot be called statically in file /var/www/enginegp/system/engine/api.php on line 42
Stack trace:
  1. Error->() /var/www/enginegp/system/engine/api.php:42
  2. include() /var/www/enginegp/system/distributor.php:77
  3. include() /var/www/enginegp/index.php:69 [] []

Task:
https://bugs.enginegp.com/view.php?id=85
https://bugs.enginegp.com/view.php?id=86
https://bugs.enginegp.com/view.php?id=87