### PR TITLE
Creation of dynamic property is deprecated in file /var/www/enginegp/…

### DIFF
--- a/system/library/html.php
+++ b/system/library/html.php
@@ -16,6 +16,8 @@ class html
 {
     var $dir = TPL;
     var $template = null;
+    var $select_template = null;
+    var $arr = array();
     var $data = array();
     var $unitblock = array();
 


### PR DESCRIPTION
…system/library/html.php

[2024-06-16T15:29:59.598218+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Creation of dynamic property html::$select_template is deprecated in file /var/www/enginegp/system/library/html.php on line 81 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/html.php:81
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/html.php:81
  3. html->get() /var/www/enginegp/system/library/html.php:53
  4. html->nav() /var/www/enginegp/system/distributor.php:71
  5. include() /var/www/enginegp/index.php:69 [] []

[2024-06-16T15:37:33.393775+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Creation of dynamic property html::$arr is deprecated in file /var/www/enginegp/system/library/html.php on line 126 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/html.php:126
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/html.php:126
  3. html->pack() /var/www/enginegp/system/library/html.php:61
  4. html->nav() /var/www/enginegp/system/distributor.php:71
  5. include() /var/www/enginegp/index.php:69 [] []