### PR TITLE
Undefined variable $aGroup in file /var/www/enginegp/system/acp/secti…

### DIFF
--- a/system/acp/sections/users/search.php
+++ b/system/acp/sections/users/search.php
@@ -20,6 +20,8 @@ $cache = $mcache->get($mkey);
 
 $nmch = null;
 
+$aGroup = array('user' => 'Пользователь', 'support' => 'Тех. поддержка', 'admin' => 'Администратор');
+
 if (is_array($cache)) {
     if ($go)
         sys::outjs($cache, $nmch);


### PR DESCRIPTION
…ons/users/search.php on line 67

[2024-06-17T23:41:49.265876+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Undefined variable $aGroup in file /var/www/enginegp/system/acp/sections/users/search.php on line 67 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/acp/sections/users/search.php:67
  2. Whoops\Run->handleError() /var/www/enginegp/system/acp/sections/users/search.php:67
  3. include() /var/www/enginegp/system/acp/sections/users/index.php:16
  4. include() /var/www/enginegp/system/acp/engine/users.php:53
  5. include() /var/www/enginegp/system/acp/distributor.php:67
  6. include() /var/www/enginegp/acp/index.php:69 [] []