### PR TITLE
Creation of dynamic property SxGeo::$b_idx_len is deprecated in file …

### DIFF
--- a/system/library/geo.php
+++ b/system/library/geo.php
@@ -33,6 +33,13 @@ class SxGeo
     protected $db;
     protected $regions_db;
     protected $cities_db;
+    protected $b_idx_len;
+    protected $id_len;
+    protected $block_len;
+    protected $max_region;
+    protected $max_city;
+    protected $max_country;
+    protected $pack;
 
     public $id2iso = array(
         '', 'AP', 'EU', 'AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'CW', 'AO', 'AQ', 'AR', 'AS', 'AT', 'AU',


### PR DESCRIPTION
…/var/www/enginegp/system/library/geo.php on line 73

[2024-06-16T15:51:28.865197+03:00] EngineGP.ERROR: Whoops\Exception\ErrorException: Creation of dynamic property SxGeo::$b_idx_len is deprecated in file /var/www/enginegp/system/library/geo.php on line 73 Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/enginegp/system/library/geo.php:73
  2. Whoops\Run->handleError() /var/www/enginegp/system/library/geo.php:73
  3. SxGeo->__construct() /var/www/enginegp/system/acp/sections/users/user.php:39
  4. include() /var/www/enginegp/system/acp/sections/users/index.php:19
  5. include() /var/www/enginegp/system/acp/engine/users.php:53
  6. include() /var/www/enginegp/system/acp/distributor.php:67
  7. include() /var/www/enginegp/acp/index.php:69 [] []

Task:
https://bugs.enginegp.com/view.php?id=90