### PR TITLE
Deprecated: preg_match(): Passing null to parameter №2 ($subject) of …

### DIFF
--- a/system/library/acpsystem.php
+++ b/system/library/acpsystem.php
@@ -85,6 +85,10 @@ class sys
 
     public static function valid($val, $type, $preg = '')
     {
+        if (!is_string($val)) {
+            return true;
+        }
+        
         switch ($type) {
             case 'promo':
                 if (!preg_match("/^[A-Za-z0-9]{2,20}$/", $val))


### PR DESCRIPTION
…type string is deprecated in /var/www/enginegp/system/library/acpsystem.php on line 114

Deprecated: preg_match(): Passing null to parameter №2 ($subject) of type string is deprecated in /var/www/enginegp/system/library/acpsystem.php on line 114

Task:
https://bugs.enginegp.com/view.php?id=94