### PR TITLE
Error: Class 'Transport' not found in file /var/www/enginegp/system/l…

### DIFF
--- a/system/library/acpsystem.php
+++ b/system/library/acpsystem.php
@@ -9,6 +9,10 @@
  * @license   https://github.com/EngineGPDev/EngineGP/blob/main/LICENSE MIT License
  */
 
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mime\Email;
+
 if (!defined('EGP'))
     exit(header('Refresh: 0; URL=http://' . $_SERVER['HTTP_HOST'] . '/404'));
 

--- a/system/library/system.php
+++ b/system/library/system.php
@@ -9,6 +9,10 @@
  * @license   https://github.com/EngineGPDev/EngineGP/blob/main/LICENSE MIT License
  */
 
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mime\Email;
+
 if (!defined('EGP'))
     exit(header('Refresh: 0; URL=http://' . $_SERVER['HTTP_HOST'] . '/404'));
 


### PR DESCRIPTION
…ibrary/system.php on line 326

[2024-07-11T03:15:38.628839+03:00] EngineGP.ERROR: Error: Class 'Transport' not found in file /var/www/enginegp/system/library/system.php on line 326 Stack trace:
  1. Error->() /var/www/enginegp/system/library/system.php:326
  2. sys->mail() /var/www/enginegp/system/sections/user/signup.php:103
  3. include() /var/www/enginegp/system/engine/user.php:35
  4. include() /var/www/enginegp/system/distributor.php:77
  5. include() /var/www/enginegp/index.php:69 [] []

Task:
https://bugs.enginegp.com/view.php?id=96