### PR TITLE
mysqli_sql_exception: Character set 'utf8mb3_general_ci' cannot be us…

### DIFF
--- a/system/library/games/games.php
+++ b/system/library/games/games.php
@@ -656,7 +656,7 @@ class games
         $sql = 'AND (';
 
         foreach ($arr as $map)
-            $sql .= ' `name` REGEXP FROM_BASE64(\'' . base64_encode('^' . $map . '\_') . '\') OR';
+            $sql .= ' `name` LIKE "' . $map . '_%" OR';
 
         return $sql == 'AND (' ? '' : substr($sql, 0, -3) . ')';
     }


### PR DESCRIPTION
…ed in conjunction with 'binary' in call to regexp_like

[2024-07-17T01:55:55.288685+03:00] EngineGP.ERROR: mysqli_sql_exception: Character set 'utf8mb3_general_ci' cannot be used in conjunction with 'binary' in call to regexp_like. in file /var/www/enginegp/system/library/sql.php on line 44
Stack trace:
  1. mysqli_sql_exception->() /var/www/enginegp/system/library/sql.php:44
  2. mysqli_query() /var/www/enginegp/system/library/sql.php:44
  3. mysql->query() /var/www/enginegp/system/sections/servers/cs/maps/list.php:36
  4. include() /var/www/enginegp/system/sections/servers/cs/maps.php:30
  5. include() /var/www/enginegp/system/sections/servers/maps.php:20
  6. include() /var/www/enginegp/system/engine/servers.php:92
  7. include() /var/www/enginegp/system/distributor.php:77
  8. include() /var/www/enginegp/index.php:69
 [] []